### PR TITLE
[Premake] Isolated internal and external dependencies

### DIFF
--- a/Editor/premake5.lua
+++ b/Editor/premake5.lua
@@ -21,11 +21,11 @@ project "Sentinel-Editor"
 
     includedirs
     {
-        "%{IncludeDir.Sentinel_Source}",
-        "%{IncludeDir.glm}",
-        "%{IncludeDir.EASTL}",
-        "%{IncludeDir.EABase}",
-        "%{IncludeDir.spdlog}"
+        "%{IncludeInternalDir.Sentinel_Source}",
+        "%{IncludeExternalDir.glm}",
+        "%{IncludeExternalDir.EASTL}",
+        "%{IncludeExternalDir.EABase}",
+        "%{IncludeExternalDir.spdlog}"
     }
 
     links

--- a/Engine/premake5.lua
+++ b/Engine/premake5.lua
@@ -27,12 +27,12 @@ project "Sentinel"
     includedirs
     {
         "Source",
-        "%{IncludeDir.GLFW}",
-        "%{IncludeDir.Glad}",
-        "%{IncludeDir.glm}",
-        "%{IncludeDir.EABase}",
-        "%{IncludeDir.EASTL}",
-        "%{IncludeDir.spdlog}"
+        "%{IncludeExternalDir.GLFW}",
+        "%{IncludeExternalDir.Glad}",
+        "%{IncludeExternalDir.glm}",
+        "%{IncludeExternalDir.EABase}",
+        "%{IncludeExternalDir.EASTL}",
+        "%{IncludeExternalDir.spdlog}"
     }
 
     links

--- a/Premake/customization/external_dependencies.lua
+++ b/Premake/customization/external_dependencies.lua
@@ -1,0 +1,10 @@
+-- Sentinel External Dependencies
+
+-- Include directories relative to root folder (solution directory)
+IncludeExternalDir = {}
+IncludeExternalDir["GLFW"] = "%{wks.location}/Engine/Vendor/GLFW/module/include"
+IncludeExternalDir["Glad"] = "%{wks.location}/Engine/Vendor/Glad/module/include"
+IncludeExternalDir["glm"] = "%{wks.location}/Engine/Vendor/glm/module"
+IncludeExternalDir["spdlog"] = "%{wks.location}/Engine/Vendor/spdlog/module/include"
+IncludeExternalDir["EASTL"] = "%{wks.location}/Engine/Vendor/EASTL/module/include"
+IncludeExternalDir["EABase"] = "%{wks.location}/Engine/Vendor/EASTL/module/test/packages/EABase/include/Common"

--- a/Premake/customization/internal_dependencies.lua
+++ b/Premake/customization/internal_dependencies.lua
@@ -1,0 +1,6 @@
+-- Sentinel Internal Dependencies
+
+-- Include directories relative to root folder (solution directory)
+IncludeInternalDir = {}
+IncludeInternalDir["Sentinel_Source"] = "%{wks.location}/Engine/Source"
+IncludeInternalDir["Sentinel_Vendor"] = "%{wks.location}/Engine/Vendor"

--- a/Sandbox/premake5.lua
+++ b/Sandbox/premake5.lua
@@ -15,11 +15,11 @@ project "Sandbox"
 
     includedirs
     {
-        "%{IncludeDir.Sentinel_Source}",
-        "%{IncludeDir.glm}",
-        "%{IncludeDir.EASTL}",
-        "%{IncludeDir.EABase}",
-        "%{IncludeDir.spdlog}"
+        "%{IncludeInternalDir.Sentinel_Source}",
+        "%{IncludeExternalDir.glm}",
+        "%{IncludeExternalDir.EASTL}",
+        "%{IncludeExternalDir.EABase}",
+        "%{IncludeExternalDir.spdlog}"
     }
 
     links

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,5 +1,7 @@
 include "Premake/customization/solution_items.lua"
 include "Premake/customization/clean_project.lua"
+include "Premake/customization/internal_dependencies.lua"
+include "Premake/customization/external_dependencies.lua"
 
 workspace "Sentinel"
     architecture "x86_64"
@@ -23,17 +25,6 @@ workspace "Sentinel"
     }
 
 outputdir = "%{cfg.buildcfg}-%{cfg.system}-%{cfg.architecture}"
-
--- Include directories relative to root folder (solution directory)
-IncludeDir = {}
-IncludeDir["Sentinel_Source"] = "%{wks.location}/Engine/Source"
-IncludeDir["Sentinel_Vendor"] = "%{wks.location}/Engine/Vendor"
-IncludeDir["GLFW"] = "%{wks.location}/Engine/Vendor/GLFW/module/include"
-IncludeDir["Glad"] = "%{wks.location}/Engine/Vendor/Glad/module/include"
-IncludeDir["glm"] = "%{wks.location}/Engine/Vendor/glm/module"
-IncludeDir["spdlog"] = "%{wks.location}/Engine/Vendor/spdlog/module/include"
-IncludeDir["EASTL"] = "%{wks.location}/Engine/Vendor/EASTL/module/include"
-IncludeDir["EABase"] = "%{wks.location}/Engine/Vendor/EASTL/module/test/packages/EABase/include/Common"
 
 -- Include dependencies
 group "Dependencies"


### PR DESCRIPTION
#### Describe the issue
The premake script of workspace directory has all the internal and external dependencies mentioned as a dictionary. It would be better to isolate theses dependencies in separate files for the purpose of scalability and readability.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | #11 
Other PRs this solves    | None

#### Proposed fix
Moved the internal and external dependencies to `internal_dependencies.lua` and `external_dependencies.lua` files at `Premake/customization` path

#### Additional context
See issue #14 for a similar idea for CMake.